### PR TITLE
[PRCE] Fix prce compiler for supporting \s, \S, \x, \n, etc.

### DIFF
--- a/src/plugins/PCREPlugin/config.h
+++ b/src/plugins/PCREPlugin/config.h
@@ -16,9 +16,7 @@ emulation function will be used. */
 character codes, define this macro as 1. On systems that can use "configure",
 this can be done via --enable-ebcdic. */
 
-#ifndef EBCDIC
-#define EBCDIC 0
-#endif
+//#define EBCDIC
 
 #define PCRE_STATIC
 


### PR DESCRIPTION
Fix very very older bug
