### PR TITLE
Increased LINESIZE for huge GETs

### DIFF
--- a/src/proxy.c
+++ b/src/proxy.c
@@ -131,7 +131,7 @@ char * proxy_stringtable[] = {
 	NULL
 };
 
-#define LINESIZE 4096
+#define LINESIZE 8192
 #define BUFSIZE (LINESIZE*2)
 #define FTPBUFSIZE 1536
 


### PR DESCRIPTION
Increased buffer size for too long HTTP header lines.

My experience shows that 4K buffer is not sufficient in some cases. Increasing twice its' size makes 3proxy more versatile in a small price.