### PR TITLE
copying: Remove software version 0.9 from license

### DIFF
--- a/copying
+++ b/copying
@@ -1,4 +1,4 @@
-3proxy 0.9 Public License Agreement
+3proxy Public License Agreement
 
 (c) 2000-2019 by 3APA3A (3APA3A@3proxy.ru)
 (c) 2000-2019 by 3proxy.org (http://3proxy.org/)


### PR DESCRIPTION
A version here could imply that other versions are
not available under these copying terms.