### PR TITLE
Use Pascal-Case for Proxy-Authorization header

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -55,7 +55,7 @@ int clientnegotiate(struct chain * redir, struct clientparam * param, struct soc
 			len += sprintf((char *)buf + len,
 				":%hu HTTP/1.0\r\nConnection: keep-alive\r\n", ntohs(*SAPORT(addr)));
 			if(user){
-				len += sprintf((char *)buf + len, "Proxy-authorization: Basic ");
+				len += sprintf((char *)buf + len, "Proxy-Authorization: Basic ");
 				sprintf((char *)username, "%.128s:%.128s", user, pass?pass:(unsigned char *)"");
 				en64(username, buf+len, (int)strlen((char *)username));
 				len = (int)strlen((char *)buf);


### PR DESCRIPTION
Some upsteam proxies (i.e. ProxyMesh) are failing to authenticate when mixed case is used for Proxy-Authorization header