### PR TITLE
fix: parent socks5 address length for domain type

### DIFF
--- a/src/auth.c
+++ b/src/auth.c
@@ -196,7 +196,7 @@ int clientnegotiate(struct chain * redir, struct clientparam * param, struct soc
 			    return 59;
 			case 3:
 			    if (sockgetlinebuf(param, SERVER, buf, 1, EOF, conf.timeouts[CHAIN_TO]) != 1) return 59;
-			    len = (unsigned char)buf[0];
+			    len = (unsigned char)buf[0] + 2;
 			    if (sockgetlinebuf(param, SERVER, buf, len, EOF, conf.timeouts[CHAIN_TO]) != len) return 59;
 			    break;
 			case 4:


### PR DESCRIPTION
count port length (2 bytes) for domain address type