### PR TITLE
Improvements for BSD/macOS build

### DIFF
--- a/Makefile.FreeBSD
+++ b/Makefile.FreeBSD
@@ -33,23 +33,7 @@ PLUGINS = StringsPlugin TrafficPlugin PCREPlugin PamAuth TransparentPlugin
 
 include Makefile.inc
 
-install: all
-	if [ ! -d /usr/local/3proxy/bin ]; then mkdir -p /usr/local/3proxy/bin/; fi
-	install bin/3proxy /usr/local/3proxy/bin/3proxy
-	install bin/mycrypt /usr/local/3proxy/bin/mycrypt
-	install scripts/add3proxyuser.sh /usr/local/3proxy/bin/
-	if [ -s /usr/local/etc/3proxy/3proxy.cfg ]; then
-	echo /usr/local/3proxy/3proxy.cfg already exists
-	else
-	install scripts/3proxy.cfg /usr/local/etc/3proxy/
-	if [ ! -d /var/log/3proxy/ ]; then
-	mkdir /var/log/3proxy/
-	fi
-	touch /usr/local/3proxy/passwd
-	touch /usr/local/3proxy/counters
-	touch /usr/local/3proxy/bandlimiters
-	echo Run /usr/local/3proxy/bin/add3proxyuser.sh to add \'admin\' user
-	fi
+DESTDIR		= 
 
 allplugins:
 	@list='$(PLUGINS)'; for p in $$list; do cp Makefile Makefile.var plugins/$$p; cd plugins/$$p ; make ;	cd ../.. ; done

--- a/Makefile.Linux
+++ b/Makefile.Linux
@@ -72,7 +72,6 @@ INSTALL_SYSTEMD_SCRIPT = scripts/3proxy.service
 
 CHROOTDIR	= $(DESTDIR)$(chroot_prefix)/3proxy
 CHROOTREL	= ../..$(chroot_prefix)/3proxy
-MANDIR1		= $(DESTDIR)$(man_prefix)/man/man1
 MANDIR3		= $(DESTDIR)$(man_prefix)/man/man3
 MANDIR8		= $(DESTDIR)$(man_prefix)/man/man8
 BINDIR		= $(DESTDIR)$(exec_prefix)/bin

--- a/Makefile.openwrt-mips
+++ b/Makefile.openwrt-mips
@@ -66,7 +66,6 @@ INSTALL_CFG_DEST = config
 
 INSTALL_CFG_OBJS2 = passwd counters bandlimiters
 
-MANDIR1		= $(DESTDIR)$(man_prefix)/man/man1
 MANDIR3		= $(DESTDIR)$(man_prefix)/man/man3
 MANDIR8		= $(DESTDIR)$(man_prefix)/man/man8
 BINDIR		= $(DESTDIR)$(exec_prefix)/bin

--- a/Makefile.unix-install
+++ b/Makefile.unix-install
@@ -21,7 +21,6 @@ INSTALL_CFG_DEST = config
 
 INSTALL_CFG_OBJS2 = passwd counters bandlimiters
 
-MANDIR1		= $(DESTDIR)$(man_prefix)/man/man1
 MANDIR3		= $(DESTDIR)$(man_prefix)/man/man3
 MANDIR8		= $(DESTDIR)$(man_prefix)/man/man8
 BINDIR		= $(DESTDIR)$(exec_prefix)/bin
@@ -48,10 +47,8 @@ install-etc: install-etc-dir
 	done;
 
 install-man:
-	$(INSTALL_BIN) -d $(MANDIR1)
 	$(INSTALL_BIN) -d $(MANDIR3)
 	$(INSTALL_BIN) -d $(MANDIR8)
-	$(INSTALL_DATA) man/*.1 $(MANDIR1)
 	$(INSTALL_DATA) man/*.3 $(MANDIR3)
 	$(INSTALL_DATA) man/*.8 $(MANDIR8)
 

--- a/Makefile.unix-install
+++ b/Makefile.unix-install
@@ -37,7 +37,7 @@ install-etc-default-config:
 	if [ -f $(ETCDIR)/$(INSTALL_CFG_DEST) ]; then \
 	   : ; \
 	else \
-	   $(INSTALL_DATA) $(INSTALL_CFG_OBJS) $(ETCDIR)/$(INSTALL_CFG_DEST) \
+	   $(INSTALL_DATA) $(INSTALL_CFG_OBJS) $(ETCDIR)/$(INSTALL_CFG_DEST) ; \
 	fi
 
 install-etc: install-etc-dir


### PR DESCRIPTION
* There are no `*.1` man pages, so it should not try to install them. (This produced an error for me.)
* It seems that `Makefile.unix-install` does the same job as the `install` target in `Makefile.FreeBSD`, and it is much more configurable, so it makes sense just to remove the FreeBSD-specific one in favour of the generic Unix one.