### PR TITLE
#1160: Fix HTTPS proxy for HTTPS addresses

### DIFF
--- a/src/plugins/SSLPlugin/ssl_plugin.c
+++ b/src/plugins/SSLPlugin/ssl_plugin.c
@@ -536,7 +536,7 @@ static void* ssl_filter_open(void * idata, struct srvparam * srv){
 		    SSL_CTX_set_verify(sc->srv_ctx, SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
 	    }
 	}
-#ifdef WIWHSPLICE
+#ifdef WITHSPLICE
 	srv->usesplice = 0;
 #endif
 	return sc;


### PR DESCRIPTION
There was a typo, that led builds with `-DWITHSPLICE` (default on Linux) to process https:// URLs in TLS proxy incorrectly.

Fixes #1160 #1171 