### PR TITLE
docs: update docker repository link in README

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,7 @@ Devel branch - 3proxy 10 (don't use it)
 	https://github.com/z3APA3A/3proxy/releases
 
 	Docker images:
-	https://hub.docker.com/repository/docker/3proxy/3proxy
+	https://hub.docker.com/r/3proxy/3proxy
 	Archive of old versions: https://github.com/z3APA3A/3proxy-archive
 
 * Documentation


### PR DESCRIPTION
## Description
The Docker Hub link for the 3proxy image was outdated or pointing to an incorrect repository. This PR updates the documentation to point to the official `3proxy/3proxy` repository.
<img width="971" height="368" alt="image" src="https://github.com/user-attachments/assets/1fcc406d-8976-4c09-91af-bed26075c5b5" />

## Changes
- Updated the image reference in `README.md`.